### PR TITLE
Update MICS-VZ-89TE.cpp

### DIFF
--- a/MICS-VZ-89TE/MICS-VZ-89TE.cpp
+++ b/MICS-VZ-89TE/MICS-VZ-89TE.cpp
@@ -74,7 +74,7 @@ void MICS_VZ_89TE::getVersion(void) {
 }
 
 
-bool MICS_VZ_89TE::begin() {
+void MICS_VZ_89TE::begin() {
     Wire.begin();
 }
 

--- a/MICS-VZ-89TE/MICS-VZ-89TE.h
+++ b/MICS-VZ-89TE/MICS-VZ-89TE.h
@@ -55,7 +55,7 @@ public:
     float rev;
     float crc;
     
-    bool begin(void);
+    void begin(void);
     void readSensor(void);
     void getVersion(void);
     


### PR DESCRIPTION
Fix func return type of `MICS_VZ_89TE::begin`